### PR TITLE
Visibility being returned in the listner callback was the visibility …

### DIFF
--- a/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
+++ b/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
@@ -193,7 +193,7 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
         if (!isVisible()) {
             findViewById(R.id.controller_panel).setVisibility(VISIBLE);
             if (visibilityListener != null) {
-                visibilityListener.onVisibilityChange(getVisibility());
+                visibilityListener.onVisibilityChange(VISIBLE);
             }
             alignSubtitlesView(true);
 //            updateAll();
@@ -207,7 +207,7 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
             if (tubiObservable == null || !tubiObservable.userInteracting()) {
                 findViewById(R.id.controller_panel).setVisibility(GONE);
                 if (visibilityListener != null) {
-                    visibilityListener.onVisibilityChange(getVisibility());
+                    visibilityListener.onVisibilityChange(GONE);
                 }
                 alignSubtitlesView(false);
 //            removeCallbacks(updateProgressAction);


### PR DESCRIPTION
…of the entire view, not just the controls.  Updated to reflect this.

The visibility passed in is now matching the visibility change from the controller panel.
This will allow for accurate alterations made by those who intercept the callback, with different results for different visibility states.