### PR TITLE
Offer position of seekbar upper bound relative to bottom of the screen

### DIFF
--- a/lib/src/main/java/com/tubitv/media/activities/TubiPlayerActivity.java
+++ b/lib/src/main/java/com/tubitv/media/activities/TubiPlayerActivity.java
@@ -148,12 +148,6 @@ public abstract class TubiPlayerActivity extends LifeCycleActivity implements Tu
         mTubiPlayerView = (TubiExoPlayerView) findViewById(R.id.tubitv_player);
         mTubiPlayerView.requestFocus();
         mTubiPlayerView.setActivity(this);
-        mTubiPlayerView.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
-            @Override
-            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
-
-            }
-        });
     }
 
     private void setCaption(boolean isOn) {

--- a/lib/src/main/java/com/tubitv/media/utilities/Utils.java
+++ b/lib/src/main/java/com/tubitv/media/utilities/Utils.java
@@ -1,6 +1,7 @@
 package com.tubitv.media.utilities;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -92,5 +93,13 @@ public class Utils {
      */
     public static boolean isEmpty(@Nullable String text){
         return text == null || text.equalsIgnoreCase("");
+    }
+
+    public static float dpFromPx(final Context context, final float px) {
+        return px / context.getResources().getDisplayMetrics().density;
+    }
+
+    public static float pxFromDp(final Context context, final float dp) {
+        return dp * context.getResources().getDisplayMetrics().density;
     }
 }

--- a/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
+++ b/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
@@ -22,6 +22,7 @@ import com.tubitv.media.interfaces.TrackSelectionHelperInterface;
 import com.tubitv.media.interfaces.TubiPlaybackControlInterface;
 import com.tubitv.media.interfaces.TubiPlaybackInterface;
 import com.tubitv.media.models.MediaModel;
+import com.tubitv.media.utilities.Utils;
 
 /**
  * Created by stoyan on 5/15/17.
@@ -81,6 +82,8 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
      */
     private SimpleExoPlayer mPlayer;
 
+    private float seekBarUpperBound = 0f;
+
     private final Runnable hideAction = new Runnable() {
         @Override
         public void run() {
@@ -107,6 +110,14 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
         initLayout();
     }
 
+    /**
+     * get the seekBar upper bound relative to bottom of the screen, for Auto play animation purposes.
+     * @return
+     */
+    public float getSeekBarUpperBound() {
+        return seekBarUpperBound;
+    }
+
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
@@ -120,6 +131,12 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
             }
         }
 //        updateAll();
+    }
+
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+        seekBarUpperBound = calculateSeekBarUpperBound();
     }
 
     @Override
@@ -303,5 +320,34 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
         Resources res = getResources();
         String numberofAdLeftInString = res.getQuantityString(R.plurals.view_tubi_ad_learn_more_ads_resume_shortly_text, count, count);
         this.tubiObservable.numberOfAdLeft.set(numberofAdLeftInString);
+    }
+
+    /**
+     *
+     * @return the upper bound of seek bar relative to the bottom of the screen in px.
+     */
+    public float calculateSeekBarUpperBound() {
+
+        //if the seekBarUpperBound has already been calculated, do not need to calculated the position again,
+        //because the operation is relatively expensive.
+        if(seekBarUpperBound!=0f){
+            return seekBarUpperBound;
+        }
+
+        float positionFromBottom = 0;
+
+        if (mBinding.viewTubiControllerSeekBar != null ) {
+            //because the seekbar visibility is "GONE" when first enter the playback activity, we need a special way to get
+            //control view's height.
+            int widthSpec = MeasureSpec.makeMeasureSpec(mBinding.viewTubiControllerSeekBar.getWidth(), MeasureSpec.EXACTLY);
+            int heightSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
+            mBinding.viewTubiControllerSeekBar.measure(widthSpec, heightSpec);
+            int height = mBinding.viewTubiControllerSeekBar.getMeasuredHeight();
+
+            // the control's view's height + 20dp which is the bottom guideline space.
+            positionFromBottom = height + Utils.pxFromDp(getContext(), 20);
+        }
+
+        return positionFromBottom;
     }
 }

--- a/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
+++ b/lib/src/main/java/com/tubitv/media/views/TubiPlayerControlView.java
@@ -112,7 +112,7 @@ public class TubiPlayerControlView extends ConstraintLayout implements TrackSele
 
     /**
      * get the seekBar upper bound relative to bottom of the screen, for Auto play animation purposes.
-     * @return
+     * @return if return 0f, it mean the view hasn't been created, therefore, should only called this method when view has created on the screen already.
      */
     public float getSeekBarUpperBound() {
         return seekBarUpperBound;


### PR DESCRIPTION
Problem: AutoPlay drawer need the position of the seekbar to do Animation 

Solution: calculate the seekbar's position relative to bottom of the screen:

1. two factors, the seekbar's height and also the bottom guideline space.
2. When TubiControllerView finish drawing, get the height and other positions


FAQ: because  of the controllerView is visibility is gone, we need special way to get its height, and also the position calculation is expensive, so we only need to do it once
