### PR TITLE
Subtitle appear on ads

### DIFF
--- a/lib/src/main/java/com/tubitv/media/fsm/concrete/AdPlayingState.java
+++ b/lib/src/main/java/com/tubitv/media/fsm/concrete/AdPlayingState.java
@@ -108,6 +108,9 @@ public class AdPlayingState extends BaseState {
             adPlayer.setPlayWhenReady(true);
             adPlayer.addAnalyticsListener(componentController.getAdPlayingMonitor());
             adPlayer.setMetadataOutput(componentController.getAdPlayingMonitor());
+
+            //hide the subtitle view when ad is playing
+            ((TubiExoPlayerView) controller.getExoPlayerView()).getSubtitleView().setVisibility(View.INVISIBLE);
         }
     }
 

--- a/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
+++ b/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
@@ -6,6 +6,7 @@ import android.webkit.WebView;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
+import com.tubitv.media.bindings.UserController;
 import com.tubitv.media.controller.PlayerAdLogicController;
 import com.tubitv.media.controller.PlayerUIController;
 import com.tubitv.media.fsm.BaseState;
@@ -84,6 +85,11 @@ public class MoviePlayingState extends BaseState {
         controller.isPlayingAds = false;
 
         hideVpaidNShowPlayer(controller);
+
+        //when return to the movie playing state, show the subtitle if necessary
+        if (shouldShowSubtitle()) {
+            ((TubiExoPlayerView) controller.getExoPlayerView()).getSubtitleView().setVisibility(View.INVISIBLE);
+        }
     }
 
     private void updatePlayerPosition(SimpleExoPlayer moviePlayer, PlayerUIController controller) {
@@ -111,6 +117,20 @@ public class MoviePlayingState extends BaseState {
             vpaidEWebView.loadUrl(VpaidClient.EMPTY_URL);
             vpaidEWebView.clearHistory();
         }
+    }
+
+    private boolean shouldShowSubtitle() {
+        boolean result = false;
+
+        TubiExoPlayerView view = (TubiExoPlayerView) controller.getExoPlayerView();
+
+        UserController controller = (UserController) view.getPlayerController();
+
+        if (movieMedia.getSubtitlesUrl() != null && controller.isSubtitleEnabled.get()) {
+            return true;
+        }
+
+        return result;
     }
 
 }

--- a/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
+++ b/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
@@ -120,17 +120,16 @@ public class MoviePlayingState extends BaseState {
     }
 
     private boolean shouldShowSubtitle() {
-        boolean result = false;
 
         TubiExoPlayerView view = (TubiExoPlayerView) controller.getExoPlayerView();
 
         UserController controller = (UserController) view.getPlayerController();
 
-        if (movieMedia.getSubtitlesUrl() != null && controller.isSubtitleEnabled.get()) {
+        if (controller.videoHasSubtitle.get() && controller.isSubtitleEnabled.get()) {
             return true;
         }
 
-        return result;
+        return false;
     }
 
 }

--- a/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
+++ b/lib/src/main/java/com/tubitv/media/fsm/concrete/MoviePlayingState.java
@@ -88,7 +88,7 @@ public class MoviePlayingState extends BaseState {
 
         //when return to the movie playing state, show the subtitle if necessary
         if (shouldShowSubtitle()) {
-            ((TubiExoPlayerView) controller.getExoPlayerView()).getSubtitleView().setVisibility(View.INVISIBLE);
+            ((TubiExoPlayerView) controller.getExoPlayerView()).getSubtitleView().setVisibility(View.VISIBLE);
         }
     }
 

--- a/lib/src/main/java/com/tubitv/media/fsm/concrete/VpaidState.java
+++ b/lib/src/main/java/com/tubitv/media/fsm/concrete/VpaidState.java
@@ -16,6 +16,7 @@ import com.tubitv.media.models.AdMediaModel;
 import com.tubitv.media.models.MediaModel;
 import com.tubitv.media.models.VpaidClient;
 import com.tubitv.media.utilities.ExoPlayerLogger;
+import com.tubitv.media.views.TubiExoPlayerView;
 
 /**
  * Created by allensun on 8/1/17.
@@ -87,6 +88,9 @@ public class VpaidState extends BaseState {
 
             vpaidWebView.addJavascriptInterface(client, "TubiNativeJSInterface");
             vpaidWebView.loadUrl(fsmPlayer.getVPAID_END_POINT());
+
+            //hide the subtitle view when vpaid is playing
+            ((TubiExoPlayerView) controller.getExoPlayerView()).getSubtitleView().setVisibility(View.INVISIBLE);
         } else {
             ExoPlayerLogger.w(Constants.FSMPLAYER_TESTING, "VpaidClient is null");
         }


### PR DESCRIPTION
fixing the subtitles appear on ad break bug:

https://app.clubhouse.io/tubi/story/13783/androidtv-subtitles-are-appearing-in-ads


how to solve:
hide subtitles when user going into adPlayingState or VpaidState, then show subtitles base on the user condition in moviePlayingState