### PR TITLE
Removing material dialog.  Not using it anywhere, and it seems to be …

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -80,7 +80,6 @@ dependencies {
     api(name: 'vaud-text-view-0.0.2', ext: 'aar')
     api(name: 'tubi-loading-view-0.0.5', ext: 'aar')
 
-    api 'com.afollestad.material-dialogs:core:0.9.4.5'
     api 'com.squareup.picasso:picasso:2.5.2'
 
     api 'com.google.android.exoplayer:exoplayer:2.8.4'


### PR DESCRIPTION
…the cause of Travis failing

Please verify we don't use MaterialDialog anymore.  This seems to be the source of the three files that Travis cannot locate.

+--- com.afollestad.material-dialogs:core:0.9.4.5 -> 0.9.6.0
|    |    +--- com.android.support:support-annotations:27.0.1 -> 27.1.1
|    |    +--- com.android.support:appcompat-v7:27.0.1 -> 27.1.1
|    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    +--- com.android.support:support-core-utils:27.1.1 (*)
|    |    |    +--- com.android.support:support-fragment:27.1.1
|    |    |    |    +--- com.android.support:support-compat:27.1.1 (*)
|    |    |    |    +--- com.android.support:support-core-ui:27.1.1
|    |    |    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    |    |    +--- com.android.support:support-compat:27.1.1 (*)
|    |    |    |    |    \--- com.android.support:support-core-utils:27.1.1 (*)
|    |    |    |    +--- com.android.support:support-core-utils:27.1.1 (*)
|    |    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    |    +--- android.arch.lifecycle:livedata-core:1.1.0
|    |    |    |    |    +--- android.arch.lifecycle:common:1.1.0 -> 1.1.1 (*)
|    |    |    |    |    +--- android.arch.core:common:1.1.0 -> 1.1.1 (*)
|    |    |    |    |    \--- android.arch.core:runtime:1.1.0 -> 1.1.1
|    |    |    |    |         +--- com.android.support:support-annotations:26.1.0 -> 27.1.1
|    |    |    |    |         \--- android.arch.core:common:1.1.1 (*)
|    |    |    |    \--- android.arch.lifecycle:viewmodel:1.1.0
|    |    |    +--- com.android.support:support-vector-drawable:27.1.1
|    |    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    |    \--- com.android.support:support-compat:27.1.1 (*)
|    |    |    \--- com.android.support:animated-vector-drawable:27.1.1
|    |    |         +--- com.android.support:support-vector-drawable:27.1.1 (*)
|    |    |         \--- com.android.support:support-core-ui:27.1.1 (*)
|    |    +--- com.android.support:recyclerview-v7:27.0.1 -> 27.1.1
|    |    |    +--- com.android.support:support-annotations:27.1.1
|    |    |    +--- com.android.support:support-compat:27.1.1 (*)
|    |    |    \--- com.android.support:support-core-ui:27.1.1 (*)
|    |    \--- me.zhanghai.android.materialprogressbar:library:1.4.2
|    |         +--- com.android.support:appcompat-v7:26.0.2 -> 27.1.1 (*)
|    |         \--- com.android.support:support-annotations:26.0.2 -> 27.1.1