### PR TITLE
Moving remaining google declerations to occur before jfrog in all cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
     ext.kotlin_version = '1.2.61'
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
@@ -16,11 +16,11 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenCentral()
         maven { url 'https://maven.fabric.io/public' }
         maven { url "http://dl.bintray.com/tubitv/UI" } //TODO remove once jcenter hosts VaudTextView
-        google()
     }
 }
 


### PR DESCRIPTION
The goal is for google maven to be checked before jcenter (where certain files are not found)