### PR TITLE
Remove hard code video format limitation

### DIFF
--- a/app/src/main/java/com/tubitv/media/demo/SelectionActivity.java
+++ b/app/src/main/java/com/tubitv/media/demo/SelectionActivity.java
@@ -16,7 +16,7 @@ import com.tubitv.media.models.MediaModel;
  */
 public class SelectionActivity extends Activity {
 
-    private static final String VIDEO_URL = "https://tungsten.aaplimg.com/VOD/bipbop_adv_fmp4_example/master.m3u8";
+    private static final String VIDEO_URL = "http://techslides.com/demos/sample-videos/small.mp4";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/lib/src/main/java/com/tubitv/media/models/MediaModel.java
+++ b/lib/src/main/java/com/tubitv/media/models/MediaModel.java
@@ -108,7 +108,7 @@ public class MediaModel implements Serializable {
     }
 
     public String getMediaExtension() {
-        return "m3u8";
+        return null;
     }
 
     public MediaSource getMediaSource() {


### PR DESCRIPTION
### Open issue: https://github.com/Tubitv/TubiPlayer/issues/98

### Problem: 
Currently, we hardcore the `MediaModel` to only accept `.m3u8` format, that puts the limitation of `Tubiplayer` only accept `hls` video format.

### solution 
By removing the hardcode  `getMediaExtension` is `MediaModel`, the Tubiplayer will automatically create different `MediaSource` base on url extension.

See below logic for handle automatically `MediaSource` creation: https://github.com/Tubitv/TubiPlayer/blob/master/lib/src/main/java/com/tubitv/media/activities/TubiPlayerActivity.java#L202